### PR TITLE
perf: add _chainId and _chainIdRpc in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,6 +16,8 @@ declare module "ganache-core" {
 
   namespace Ganache {
     export interface IProviderOptions {
+      _chainId?: number;
+      _chainIdRpc?: number;
       account_keys_path?: string;
       accounts?: object[];
       allowUnlimitedContractSize?: boolean;


### PR DESCRIPTION
Without these types, I cannot set the `_chainId` field when spinning up an instance of Ganache programatically:

```
Argument of type '{ _chainId: number; default_balance_ether: number; gasLimit: number; mnemonic: string; network_id: number; }' is not assignable to parameter of type 'IProviderOptions'.

Object literal may only specify known properties, and '_chainId' does not exist in type 'IProviderOptions'.ts(2345)
```